### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ ALAlertBanner uses [Core Animation](https://developer.apple.com/library/mac/docu
 
 Installation is easy.
 
-### Cocoapods
+### CocoaPods
 
 1. Add ```pod 'ALAlertBanner', '~>0.3.1'``` to your Podfile
 2. ```#import <ALAlertBanner/ALAlertBanner.h>``` in your view of choice


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
